### PR TITLE
Added support for Int List in Narrow operand

### DIFF
--- a/src/main/java/com/github/jamesnetherton/zulip/client/api/event/request/RegisterEventQueueApiRequest.java
+++ b/src/main/java/com/github/jamesnetherton/zulip/client/api/event/request/RegisterEventQueueApiRequest.java
@@ -35,7 +35,7 @@ public class RegisterEventQueueApiRequest extends ZulipApiRequest implements Exe
         if (narrows.length > 0) {
             String[][] stringNarrows = new String[narrows.length][2];
             for (int i = 0; i < narrows.length; i++) {
-                stringNarrows[i] = new String[] { narrows[i].getOperator(), narrows[i].getOperand() };
+                stringNarrows[i] = new String[] { narrows[i].getOperator(), narrows[i].getOperand().toString() };
             }
 
             putParamAsJsonString(NARROW, stringNarrows);

--- a/src/main/java/com/github/jamesnetherton/zulip/client/api/narrow/Narrow.java
+++ b/src/main/java/com/github/jamesnetherton/zulip/client/api/narrow/Narrow.java
@@ -2,6 +2,8 @@ package com.github.jamesnetherton.zulip.client.api.narrow;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /**
  * A narrow is a set of filters for Zulip messages.
  *
@@ -13,7 +15,7 @@ public class Narrow {
     private final String operator;
 
     @JsonProperty
-    private final String operand;
+    private final Object operand;
 
     @JsonProperty
     private final boolean negated;
@@ -25,7 +27,7 @@ public class Narrow {
      * @param operand  The operand that the narrow will apply to
      * @param negated  Whether the narrow is negated
      */
-    public Narrow(String operator, String operand, boolean negated) {
+    public Narrow(String operator, Object operand, boolean negated) {
         this.operator = operator;
         this.operand = operand;
         this.negated = negated;
@@ -39,6 +41,17 @@ public class Narrow {
      * @return          The {@link Narrow} constructed from the operator and operand
      */
     public static Narrow of(String operator, String operand) {
+        return new Narrow(operator, operand, false);
+    }
+
+    /**
+     * Creates a {@link Narrow}.
+     *
+     * @param  operator The operator that the narrow will apply to
+     * @param  operand  The operand that the narrow will apply to
+     * @return          The {@link Narrow} constructed from the operator and operand
+     */
+    public static Narrow of(String operator, List<Integer> operand) {
         return new Narrow(operator, operand, false);
     }
 
@@ -57,7 +70,7 @@ public class Narrow {
         return operator;
     }
 
-    public String getOperand() {
+    public Object getOperand() {
         return operand;
     }
 


### PR DESCRIPTION
see: [](https://zulip.com/api/construct-narrow#channel-and-user-ids)

Problem addressed: 
Fixing issue with getting dm messages by userId:

example call from web UI:

https://chat.foxminded.ua/json/messages?anchor=834373&num_before=50&num_after=50&narrow=%5B%7B%22negated%22%3Afalse%2C%22operator%22%3A%22dm%22%2C%22operand%22%3A%5B14%5D%7D%5D&client_gravatar=true

narrow here is:
```
[
    {
        "negated": false,
        "operator": "dm",
        "operand": [14]
    }
]
```
