### PR TITLE
Fix EventPoller long-polling correctness

### DIFF
--- a/src/main/java/com/github/jamesnetherton/zulip/client/api/event/EventPoller.java
+++ b/src/main/java/com/github/jamesnetherton/zulip/client/api/event/EventPoller.java
@@ -76,8 +76,7 @@ public class EventPoller {
                             for (MessageEvent event : messageEvents) {
                                 eventListenerExecutorService.submit(() -> {
                                     Message message = event.getMessage();
-                                    if (message == null
-                                            || (message.getContent() != null && message.getContent().equals("heartbeat"))) {
+                                    if (message == null) {
                                         return;
                                     }
                                     configuration.getListener().onEvent(message);
@@ -87,14 +86,13 @@ public class EventPoller {
                             messageEvents.stream()
                                     .max(Comparator.comparing(Event::getId))
                                     .ifPresent(event -> lastEventId = event.getId());
-
-                            Thread.sleep(5000);
                         } catch (ZulipClientException e) {
                             LOG.fine("Error processing events - " + e.getMessage());
                             if (e.getCode() != null && e.getCode().equals("BAD_EVENT_QUEUE_ID")) {
                                 // Queue may have been garbage collected so recreate it
                                 try {
                                     queue = createQueue.execute();
+                                    lastEventId = queue.getLastEventId();
                                 } catch (ZulipClientException zulipClientException) {
                                     LOG.warning("Error recreating message queue - " + e.getMessage());
                                 }
@@ -105,8 +103,6 @@ public class EventPoller {
                             } catch (InterruptedException ex) {
                                 Thread.currentThread().interrupt();
                             }
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- **Remove `Thread.sleep(5000)` from the success path** — the Zulip long-polling model requires issuing the next `GET /events` request immediately after each response. The sleep was introducing 5 s of unnecessary latency and effectively degrading the poller to dumb interval polling.
- **Reset `lastEventId` after queue recreation on `BAD_EVENT_QUEUE_ID`** — the old event ID is meaningless on a newly registered queue. Not resetting it could cause a stale-ID loop that triggers another `BAD_EVENT_QUEUE_ID` immediately.
- **Remove dead heartbeat content check** — `message == null` already filters out non-message events (including heartbeats whose `type` is `"heartbeat"` and have no `message` field). The string comparison `message.getContent().equals("heartbeat")` was never reachable.
- **Remove now-dead `catch (InterruptedException)`** — nothing in the outer `try` block throws it after the sleep was removed.

## Test plan

- [ ] Existing unit tests pass (`./mvnw test`)
- [ ] Integration test against a live Zulip server (`./mvnw verify -Dit.test=ZulipEventIT`) confirms events are delivered without the 5 s inter-poll delay and that queue recreation correctly resumes from the new queue's last event ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)