### PR TITLE
Make ZulipEventIT more resilient

### DIFF
--- a/src/test/java/com/github/jamesnetherton/zulip/client/api/integration/event/ZulipEventIT.java
+++ b/src/test/java/com/github/jamesnetherton/zulip/client/api/integration/event/ZulipEventIT.java
@@ -8,20 +8,29 @@ import com.github.jamesnetherton.zulip.client.api.event.EventPoller;
 import com.github.jamesnetherton.zulip.client.api.event.MessageEventListener;
 import com.github.jamesnetherton.zulip.client.api.integration.ZulipIntegrationTestBase;
 import com.github.jamesnetherton.zulip.client.api.message.Message;
-import com.github.jamesnetherton.zulip.client.api.message.MessageService;
 import com.github.jamesnetherton.zulip.client.api.narrow.Narrow;
+import com.github.jamesnetherton.zulip.client.api.stream.StreamSubscription;
 import com.github.jamesnetherton.zulip.client.api.stream.StreamSubscriptionRequest;
 import com.github.jamesnetherton.zulip.client.exception.ZulipClientException;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class ZulipEventIT extends ZulipIntegrationTestBase {
+
+    private static final String TOPIC = "testtopic";
+    private static final Duration STREAM_READY_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration MESSAGE_SEND_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration EVENT_DELIVERY_TIMEOUT = Duration.ofSeconds(60);
 
     @Test
     public void messageEvents() throws Exception {
@@ -41,22 +50,12 @@ public class ZulipEventIT extends ZulipIntegrationTestBase {
 
     @Test
     public void messageEventsWithNarrow() throws Exception {
-        List<String> messages = Collections.synchronizedList(new ArrayList<>());
+        List<String> messages = new CopyOnWriteArrayList<>();
 
-        String streamA = UUID.randomUUID().toString().split("-")[0];
-        String streamB = UUID.randomUUID().toString().split("-")[0];
+        String streamA = randomStreamName();
+        String streamB = randomStreamName();
 
-        zulip.streams().subscribe(
-                StreamSubscriptionRequest.of(streamA, streamA),
-                StreamSubscriptionRequest.of(streamB, streamB)).execute();
-
-        await().atMost(30, TimeUnit.SECONDS)
-                .ignoreExceptions()
-                .until(() -> {
-                    zulip.streams().getStreamId(streamA).execute();
-                    zulip.streams().getStreamId(streamB).execute();
-                    return true;
-                });
+        subscribeToStreams(streamA, streamB);
 
         EventPoller eventPoller = zulip.events().captureMessageEvents(new MessageEventListener() {
             @Override
@@ -68,47 +67,29 @@ public class ZulipEventIT extends ZulipIntegrationTestBase {
         try {
             eventPoller.start();
 
-            MessageService messageService = zulip.messages();
-            for (int i = 0; i < 10; i++) {
-                String streamName = i % 2 == 0 ? streamA : streamB;
-                int finalI = i;
-                await().atMost(10, TimeUnit.SECONDS)
-                        .pollInterval(1, TimeUnit.SECONDS)
-                        .ignoreExceptions()
-                        .until(() -> {
-                            messageService
-                                    .sendStreamMessage("Stream " + streamName + " Content " + finalI, streamName, "testtopic")
-                                    .execute();
-                            return true;
-                        });
-            }
+            List<String> expected = new ArrayList<>();
+            List<String> notExpected = new ArrayList<>();
 
-            await().atMost(30, TimeUnit.SECONDS).until(() -> messages.size() == 5);
-
-            int count = 0;
             for (int i = 0; i < 5; i++) {
-                int finalCount = count;
-                assertTrue(
-                        messages.stream().anyMatch(message -> message.equals("Stream " + streamA + " Content " + finalCount)));
-
-                count += 2;
+                notExpected.add(sendStreamMessage(streamB, "Stream " + streamB + " Content " + i));
+                expected.add(sendStreamMessage(streamA, "Stream " + streamA + " Content " + i));
             }
+
+            await().atMost(EVENT_DELIVERY_TIMEOUT)
+                    .until(() -> messages.containsAll(expected));
+
+            assertTrue(Collections.disjoint(messages, notExpected),
+                    "Messages not matching the event narrow were captured: " + messages);
         } finally {
             eventPoller.stop();
         }
     }
 
     private void assertMessageEvents(ExecutorService executorService) throws Exception {
-        List<String> messages = Collections.synchronizedList(new ArrayList<>());
+        List<String> messages = new CopyOnWriteArrayList<>();
 
-        String streamName = "stream" + UUID.randomUUID().toString().split("-")[0];
-        StreamSubscriptionRequest subscriptionRequest = StreamSubscriptionRequest.of(streamName, streamName);
-        zulip.streams().subscribe(subscriptionRequest).execute();
-
-        await().atMost(30, TimeUnit.SECONDS).until(() -> zulip.streams().getAll()
-                .execute()
-                .stream()
-                .anyMatch(stream -> stream.getName().equals(streamName)));
+        String streamName = randomStreamName();
+        subscribeToStreams(streamName);
 
         MessageEventListener listener = new MessageEventListener() {
             @Override
@@ -127,22 +108,51 @@ public class ZulipEventIT extends ZulipIntegrationTestBase {
         try {
             eventPoller.start();
 
-            MessageService messageService = zulip.messages();
+            List<String> expected = new ArrayList<>();
             for (int i = 0; i < 3; i++) {
-                messageService.sendStreamMessage("Test Content " + i, streamName, "testtopic").execute();
+                expected.add(sendStreamMessage(streamName, "Test Content " + i));
             }
 
-            await().atMost(30, TimeUnit.SECONDS).until(() -> messages.size() == 3);
-
-            for (int i = 0; i < 3; i++) {
-                int finalI = i;
-                assertTrue(messages.stream().anyMatch(message -> message.equals("Test Content " + finalI)));
-            }
-        } catch (ZulipClientException e) {
-            e.printStackTrace();
-            throw e;
+            await().atMost(EVENT_DELIVERY_TIMEOUT)
+                    .until(() -> messages.containsAll(expected));
         } finally {
             eventPoller.stop();
         }
+    }
+
+    private static String randomStreamName() {
+        return "stream" + UUID.randomUUID().toString().split("-")[0];
+    }
+
+    private void subscribeToStreams(String... streamNames) throws ZulipClientException {
+        StreamSubscriptionRequest[] subscriptionRequests = Arrays.stream(streamNames)
+                .map(streamName -> StreamSubscriptionRequest.of(streamName, streamName))
+                .toArray(StreamSubscriptionRequest[]::new);
+
+        zulip.streams().subscribe(subscriptionRequests).execute();
+
+        List<String> expectedStreams = Arrays.asList(streamNames);
+        await().atMost(STREAM_READY_TIMEOUT)
+                .ignoreExceptions()
+                .until(() -> {
+                    Set<String> subscribed = zulip.streams()
+                            .getSubscribedStreams()
+                            .execute()
+                            .stream()
+                            .map(StreamSubscription::getName)
+                            .collect(Collectors.toSet());
+                    return subscribed.containsAll(expectedStreams);
+                });
+    }
+
+    private String sendStreamMessage(String streamName, String content) {
+        await().atMost(MESSAGE_SEND_TIMEOUT)
+                .pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .until(() -> {
+                    zulip.messages().sendStreamMessage(content, streamName, TOPIC).execute();
+                    return true;
+                });
+        return content;
     }
 }


### PR DESCRIPTION
`ZulipEventIT` has been flaky. The most frequent failure was:

```
org.awaitility.core.ConditionTimeoutException: Condition with Lambda expression in ZulipEventIT was not fulfilled within 10 seconds.
Caused by: ZulipClientException: Invalid data type for channel
	at SendMessageApiRequest.execute(SendMessageApiRequest.java:199)
```

`messageEventsWithNarrow` generated stream names from a bare UUID fragment. The server parses the send message `to` parameter as JSON before falling back to treating it as a channel name, so an 8 character hex fragment that happens to be all digits (`12345678`) or a valid float (`1e234567`) is rejected with `Invalid data type for channel`. Since the send was wrapped in `ignoreExceptions()`, this permanent error was retried until the timeout expired. Stream names are now always prefixed, as `messageEvents` already did.

Other resiliency improvements:

* Wait for the expected message content rather than an exact message count. `messages.size() == 3` could never be satisfied if any additional event was delivered, e.g. a channel creation notification or a replayed event after the poller recreates a garbage collected queue.
* Publish to the non narrowed stream first in each iteration so the last message sent is always one the narrow matches. Once it arrives, any message that wrongly slipped through the narrow will already have been delivered, so the assertion is no longer racy.
* Wait on the stream subscriptions becoming visible instead of the streams existing, since subscription is what governs event delivery. Both tests now share the same guard.
* Retry message sends in both tests, previously only the narrow test did. Retries are safe now that the assertions tolerate duplicates.
* Capture events in a `CopyOnWriteArrayList`. The previous `Collections.synchronizedList` was streamed over from the test thread while the poller appended to it, without holding its lock.
* Event delivery timeouts raised to 60s.

Verified with 5 consecutive green runs of `./mvnw verify -Dit.test=ZulipEventIT` against a live Zulip 12.1 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)